### PR TITLE
changed webob response body type to json_body

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='staff_graded-xblock',
-    version='0.6',
+    version='0.7',
     description='Staff Graded XBlock',   # TODO: write a better description.
     license='AGPL v3',          # TODO: choose a license: 'AGPL v3' and 'Apache 2.0' are popular.
     classifiers=[

--- a/staff_graded/staff_graded.py
+++ b/staff_graded/staff_graded.py
@@ -214,7 +214,7 @@ class StaffGradedXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
                      data.get('total', 0),
                      len(data.get('error_rows', [])),
                      data.get('waiting', False))
-        return Response(json.dumps(data), content_type='application/json')
+        return Response(json_body=data)
 
     @XBlock.handler
     def csv_export_handler(self, request, suffix=''):  # pylint: disable=unused-argument
@@ -258,7 +258,7 @@ class StaffGradedXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
             else:
                 data = {'waiting': True, 'result_id': result_id}
                 log.info('Still waiting for %s', result_id)
-        return Response(json.dumps(data), content_type='application/json')
+        return Response(json_body=data)
 
     def max_score(self):
         return self.weight


### PR DESCRIPTION
## [PROD-1244](https://openedx.atlassian.net/browse/PROD-1244)

import of CSV score in graded xblock caused exception `TypeError: You cannot set the body to a text value without a charset` which is due to update in `webob` version. It is fixed by changing body in `Response()` to `json_body()`
For more context review this [thread](https://github.com/Pylons/webob/issues/304#issuecomment-270039661).

[Sandbox](https://prod1244.sandbox.edx.org/)

## Test

1. Add Staff Graded Points problem in unit and publish.
2. On Problem page 1, click "export scores" 
3. Obtain resulting .csv, edit it off-platform to include new scores .
4. Click Import scores and select the newly-edited CSV.


