### PR TITLE
add empty JS function for block initialization on LMS

### DIFF
--- a/staff_graded/static/js/src/staff_graded.js
+++ b/staff_graded/static/js/src/staff_graded.js
@@ -103,4 +103,7 @@
 
   };
 
+  this.StaffGradedXBlock = function(runtime, element) {
+  };
+
 }).call(this);


### PR DESCRIPTION
- This PR adds an empty JS function that is called when initializing fragment(Ref: https://github.com/edx/staff_graded-xblock/blob/master/staff_graded/staff_graded.py#L99) on LMS. The absence of function is raising JS errors and is causing issues with other Xblocks' rendering.

Note: The empty function is added just to allow the initialization. This was done considering the function never existed and probably doesn't affect the block functionality. 

[PROD-2007](https://openedx.atlassian.net/browse/PROD-2007)