### PR TITLE
constrain importlib-metadata

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,3 +7,7 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
+
+# Needed to resolve tox requirements with requirements compiled before it
+# Can remove when tox removes <2 constraint
+importlib-metadata <2


### PR DESCRIPTION
make upgrade failed because we couldn't resolve `importlib-metadata` versions.
I will manually run the upgrade job again after this merges because I had strange behavior attempting to upgrade locally 