### PR TITLE
unpinned importlib-metadata constraint

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,14 +13,14 @@ chardet==3.0.4            # via requests
 django-crum==0.7.7        # via super-csv
 django-model-utils==4.0.0  # via edx-bulk-grades, edx-celeryutils, super-csv
 django==2.2.16            # via django-crum, django-model-utils, djangorestframework, edx-bulk-grades, edx-celeryutils, jsonfield2, super-csv
-djangorestframework==3.11.1  # via super-csv
+djangorestframework==3.12.1  # via super-csv
 edx-bulk-grades==0.8.1    # via -r requirements/base.in
 edx-celeryutils==0.5.2    # via super-csv
 edx-opaque-keys==2.1.1    # via edx-bulk-grades
 fs==2.4.11                # via xblock
 future==0.18.2            # via edx-celeryutils
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via kombu, markdown, path
+importlib-metadata==2.0.0  # via kombu, markdown, path
 jsonfield2==4.0.0.post0   # via edx-celeryutils
 kombu==4.6.11             # via celery
 lxml==4.5.2               # via xblock
@@ -38,9 +38,9 @@ requests==2.24.0          # via edx-bulk-grades, slumber
 simplejson==3.17.2        # via super-csv, xblock-utils
 six==1.15.0               # via edx-bulk-grades, edx-opaque-keys, fs, python-dateutil, stevedore, xblock
 slumber==0.7.1            # via edx-bulk-grades
-sqlparse==0.3.1           # via django
+sqlparse==0.4.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
-super-csv==1.0.1          # via edx-bulk-grades
+super-csv==1.0.2          # via edx-bulk-grades
 typing==3.7.4.3           # via fs
 urllib3==1.25.10          # via requests
 vine==1.3.0               # via amqp, celery

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,7 +7,3 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
-
-# Needed to resolve tox requirements with requirements compiled before it
-# Can remove when tox removes <2 constraint
-importlib-metadata <2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,7 +14,7 @@ certifi==2020.6.20        # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint, pip-tools
-codecov==2.1.9            # via -r requirements/travis.in
+codecov==2.1.10           # via -r requirements/travis.in
 coverage==5.3             # via codecov, pytest-cov
 distlib==0.3.1            # via -r requirements/tox.txt, virtualenv
 django-appconf==1.0.4     # via django-statici18n
@@ -22,7 +22,7 @@ django-crum==0.7.7        # via -r requirements/base.txt, super-csv
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-bulk-grades, edx-celeryutils, super-csv
 django-statici18n==2.0.0  # via -r requirements/dev.in
 django==2.2.16            # via -r requirements/base.txt, django-appconf, django-crum, django-model-utils, django-statici18n, djangorestframework, edx-bulk-grades, edx-celeryutils, edx-i18n-tools, jsonfield2, super-csv
-djangorestframework==3.11.1  # via -r requirements/base.txt, super-csv
+djangorestframework==3.12.1  # via -r requirements/base.txt, super-csv
 edx-bulk-grades==0.8.1    # via -r requirements/base.in, -r requirements/base.txt
 edx-celeryutils==0.5.2    # via -r requirements/base.txt, super-csv
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
@@ -32,9 +32,9 @@ filelock==3.0.12          # via -r requirements/tox.txt, tox, virtualenv
 fs==2.4.11                # via -r requirements/base.txt, xblock
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils
 gitdb==4.0.5              # via gitpython
-gitpython==3.1.8          # via transifex-client
+gitpython==3.1.9          # via transifex-client
 idna==2.10                # via -r requirements/base.txt, requests
-importlib-metadata==1.7.0  # via -r requirements/base.txt, -r requirements/tox.txt, kombu, markdown, path, pluggy, pytest, tox, virtualenv
+importlib-metadata==2.0.0  # via -r requirements/base.txt, -r requirements/tox.txt, kombu, markdown, path, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/tox.txt, virtualenv
 iniconfig==1.0.1          # via pytest
 isort==4.3.21             # via pylint
@@ -46,7 +46,6 @@ mako==1.1.3               # via -r requirements/base.txt, xblock-utils
 markdown==3.2.2           # via -r requirements/base.in, -r requirements/base.txt
 markupsafe==1.1.1         # via -r requirements/base.txt, mako, xblock
 mccabe==0.6.1             # via pylint
-more-itertools==8.5.0     # via pytest
 packaging==20.4           # via -r requirements/tox.txt, pytest, tox
 path.py==12.5.0           # via -r requirements/base.in, -r requirements/base.txt, edx-i18n-tools
 path==13.1.0              # via -r requirements/base.txt, path.py
@@ -63,7 +62,7 @@ pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/tox.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.in
-pytest==6.0.2             # via pytest-cov
+pytest==6.1.1             # via pytest-cov
 python-dateutil==2.8.1    # via -r requirements/base.txt, xblock
 python-slugify==4.0.1     # via transifex-client
 pytz==2020.1              # via -r requirements/base.txt, celery, django, fs, xblock
@@ -73,18 +72,18 @@ simplejson==3.17.2        # via -r requirements/base.txt, super-csv, xblock-util
 six==1.15.0               # via -r requirements/base.txt, -r requirements/tox.txt, -r requirements/travis.in, astroid, django-statici18n, edx-bulk-grades, edx-i18n-tools, edx-lint, edx-opaque-keys, fs, packaging, pathlib2, pip-tools, python-dateutil, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/base.txt, edx-bulk-grades
 smmap==3.0.4              # via gitdb
-sqlparse==0.3.1           # via -r requirements/base.txt, django
+sqlparse==0.4.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
-super-csv==1.0.1          # via -r requirements/base.txt, edx-bulk-grades
+super-csv==1.0.2          # via -r requirements/base.txt, edx-bulk-grades
 text-unidecode==1.3       # via python-slugify
 toml==0.10.1              # via -r requirements/tox.txt, pytest, tox
-tox==3.20.0               # via -r requirements/tox.in, -r requirements/tox.txt
-transifex-client==0.13.11  # via -r requirements/dev.in
+tox==3.20.1               # via -r requirements/tox.in, -r requirements/tox.txt
+transifex-client==0.13.12  # via -r requirements/dev.in
 typed-ast==1.4.1          # via astroid
 typing==3.7.4.3           # via -r requirements/base.txt, fs
 urllib3==1.25.10          # via -r requirements/base.txt, requests, transifex-client
 vine==1.3.0               # via -r requirements/base.txt, amqp, celery
-virtualenv==20.0.31       # via -r requirements/tox.txt, tox
+virtualenv==20.0.34       # via -r requirements/tox.txt, tox
 web-fragments==0.3.2      # via -r requirements/base.in, -r requirements/base.txt, xblock, xblock-utils
 webob==1.8.6              # via -r requirements/base.txt, xblock
 wrapt==1.11.2             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,7 +18,7 @@ coverage==5.3             # via pytest-cov
 django-crum==0.7.7        # via -r requirements/base.txt, super-csv
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-bulk-grades, edx-celeryutils, super-csv
 django==2.2.16            # via -r requirements/base.txt, django-crum, django-model-utils, djangorestframework, edx-bulk-grades, edx-celeryutils, jsonfield2, super-csv
-djangorestframework==3.11.1  # via -r requirements/base.txt, super-csv
+djangorestframework==3.12.1  # via -r requirements/base.txt, super-csv
 edx-bulk-grades==0.8.1    # via -r requirements/base.txt
 edx-celeryutils==0.5.2    # via -r requirements/base.txt, super-csv
 edx-lint==1.5.2           # via -r requirements/test.in
@@ -26,7 +26,7 @@ edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-bulk-grades
 fs==2.4.11                # via -r requirements/base.txt, xblock
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils
 idna==2.10                # via -r requirements/base.txt, requests
-importlib-metadata==1.7.0  # via -r requirements/base.txt, kombu, markdown, path, pluggy, pytest
+importlib-metadata==2.0.0  # via -r requirements/base.txt, kombu, markdown, path, pluggy, pytest
 iniconfig==1.0.1          # via pytest
 isort==4.3.21             # via pylint
 jsonfield2==4.0.0.post0   # via -r requirements/base.txt, edx-celeryutils
@@ -37,7 +37,6 @@ mako==1.1.3               # via -r requirements/base.txt, xblock-utils
 markdown==3.2.2           # via -r requirements/base.txt
 markupsafe==1.1.1         # via -r requirements/base.txt, mako, xblock
 mccabe==0.6.1             # via pylint
-more-itertools==8.5.0     # via pytest
 packaging==20.4           # via pytest
 path.py==12.5.0           # via -r requirements/base.txt
 path==13.1.0              # via -r requirements/base.txt, path.py
@@ -52,7 +51,7 @@ pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.1        # via -r requirements/test.in
-pytest==6.0.2             # via pytest-cov
+pytest==6.1.1             # via pytest-cov
 python-dateutil==2.8.1    # via -r requirements/base.txt, xblock
 pytz==2020.1              # via -r requirements/base.txt, celery, django, fs, xblock
 pyyaml==5.3.1             # via -r requirements/base.txt, xblock
@@ -60,9 +59,9 @@ requests==2.24.0          # via -r requirements/base.txt, edx-bulk-grades, slumb
 simplejson==3.17.2        # via -r requirements/base.txt, super-csv, xblock-utils
 six==1.15.0               # via -r requirements/base.txt, astroid, edx-bulk-grades, edx-lint, edx-opaque-keys, fs, packaging, pathlib2, python-dateutil, stevedore, xblock
 slumber==0.7.1            # via -r requirements/base.txt, edx-bulk-grades
-sqlparse==0.3.1           # via -r requirements/base.txt, django
+sqlparse==0.4.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
-super-csv==1.0.1          # via -r requirements/base.txt, edx-bulk-grades
+super-csv==1.0.2          # via -r requirements/base.txt, edx-bulk-grades
 toml==0.10.1              # via pytest
 typed-ast==1.4.1          # via astroid
 typing==3.7.4.3           # via -r requirements/base.txt, fs

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -7,7 +7,7 @@
 appdirs==1.4.4            # via virtualenv
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-metadata==2.0.0  # via pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
@@ -15,6 +15,6 @@ py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
-tox==3.20.0               # via -r requirements/tox.in
-virtualenv==20.0.31       # via tox
+tox==3.20.1               # via -r requirements/tox.in
+virtualenv==20.0.34       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,12 +7,12 @@
 appdirs==1.4.4            # via -r requirements/tox.txt, virtualenv
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-codecov==2.1.9            # via -r requirements/travis.in
+codecov==2.1.10           # via -r requirements/travis.in
 coverage==5.3             # via codecov
 distlib==0.3.1            # via -r requirements/tox.txt, virtualenv
 filelock==3.0.12          # via -r requirements/tox.txt, tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via -r requirements/tox.txt, pluggy, tox, virtualenv
+importlib-metadata==2.0.0  # via -r requirements/tox.txt, pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/tox.txt, virtualenv
 packaging==20.4           # via -r requirements/tox.txt, tox
 pluggy==0.13.1            # via -r requirements/tox.txt, tox
@@ -21,7 +21,7 @@ pyparsing==2.4.7          # via -r requirements/tox.txt, packaging
 requests==2.24.0          # via codecov
 six==1.15.0               # via -r requirements/tox.txt, -r requirements/travis.in, packaging, tox, virtualenv
 toml==0.10.1              # via -r requirements/tox.txt, tox
-tox==3.20.0               # via -r requirements/tox.txt
+tox==3.20.1               # via -r requirements/tox.txt
 urllib3==1.25.10          # via requests
-virtualenv==20.0.31       # via -r requirements/tox.txt, tox
+virtualenv==20.0.34       # via -r requirements/tox.txt, tox
 zipp==1.2.0               # via -r requirements/tox.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
- `importlib-metadata<2.0.0` was causing conflicts in running `make upgrade` with `python3.5`.
- Unpinned `importlib-metadata` constraint after fixing the issue in https://github.com/pypa/virtualenv/pull/1953 and https://github.com/tox-dev/tox/pull/1682.