### PR TITLE
remove DeprecatedEdxPlatformImportWarning

### DIFF
--- a/staff_graded/staff_graded.py
+++ b/staff_graded/staff_graded.py
@@ -24,7 +24,7 @@ except ImportError:
     get_course_cohorts = lambda course_key: []
 
 try:
-    from course_modes.models import CourseMode
+    from common.djangoapps.course_modes import CourseMode
     modes_for_course = CourseMode.modes_for_course
 except ImportError:
     modes_for_course = lambda course_key: [('audit', 'Audit Track'), ('masters', "Master's Track"), ('verified', "Verified Track")]


### PR DESCRIPTION
Remove warnings when from staff_graded when running:

`manage.py lms createsuperuser`

```
2020-11-23 14:28:11,450 WARNING 240810 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/staff_graded/staff_graded.py:27: DeprecatedEdxPlatformImportWarning: Importing course_modes instead of common.djangoapps.course_modes is deprecated
  from course_modes.models import CourseMode
```