### PR TITLE
Bump version to 1.3 to trigger new PyPI release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def is_requirement(line):
 
 setup(
     name='staff_graded-xblock',
-    version='1.1',
+    version='1.3',
     description='Staff Graded XBlock',   # TODO: write a better description.
     license='AGPL v3',          # TODO: choose a license: 'AGPL v3' and 'Apache 2.0' are popular.
     classifiers=[


### PR DESCRIPTION
```
There was a v1.2 tag on GitHub,
but the version in setup.py was never bumped,
so edx-platform still installs 1.1.

A new release is needed in order to bring the
DeprecatedEdxPlatformImportWarning fix
to into production before support for
the deprecated imports is removed.
```

This is related to the [the impending removal of support for deprecated edx-platform import paths](https://github.com/edx/edx-platform/pull/25932).
