### PR TITLE
fix: remove outdated fields in openedx.yaml

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -7,7 +7,4 @@ tags:
     - library
     - xblock
 
-owner: mattcarter
 nick: staff-graded
-supporting_teams:
-  - masters-devs


### PR DESCRIPTION
Remove the Owner and Supporting Team fields as they are outdated per https://github.com/edx/repo-tools/blob/master/edx_repo_tools/modernize_openedx_yaml.py#L5

The ownership spreadsheet should be the single source of truth.

@nedbat cc @mattcarter 