### PR TITLE
Drop Python 3.5 support. Mark as conforming to OEP-7 (Python3).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- 3.5
 - 3.8
 env:
 - TOXENV=django22
@@ -22,7 +21,7 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
-    python: 3.5
+    python: 3.8
     condition: $TOXENV = quality
   password:
     secure: S7FvyGwjNYFOHGFXVoX7YR9Adm11eLgVRI5xAX2npZEnz0wbi16KCM5FI9JrDhRbLjFlL0xoPbUZiOsxQFBB5DGE2OgxXpIcvxkRMFWycyofOQ3io7OcfccpL0JZKHkW5GYh+2d+TJfoMBbV+vQfjWtJ69c9hk75saTcBesRruHC1C2AS4hDs6QrJP7Df3MF+WnxkSKOk/bfLs9u3oZ3RJLutvpas72g+I5NFTw0qDBAvpqCb2XKOGwEKFWpsgBInl9BnJcgQg46eaxBLR17hr8wIvCOtbXcM+VOgcaItPas+Lc1cuCrTGuNp4SMIGvZLO5TGzguc5WGuSmnG/cXACE2TlKy1WLRVpSyAbrdEWNaIIWImeVMjQso9APGLkyiEQTNUDCqSiaA8bHAQz97YaaWxVgKeumEx9XdSDiE+BPyFl2WB9SQ2/gE2NaMMutA7rTZsbuSOrUO5mOLLspLpBKrxu0h9CNLDxH3jzsudZ6FvVq6nQZb5FsFy3hCKLUXKLTjW6Xbu/ovTFq9+k0d62kZyev4MiDXBz/sAuBJzujAHnjQW7PLKy4l8m7GQazPmgXMe8kHuC/l1c2+OAMrM/3K1FkmXFI5FmuAM5McTZvtlgK6oLzVjnc9Vx9U13yW25rQ8B7N0xSzKsk8sOvYZ4Gn2SRHGVITg3j8hAuQ9gE=

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,6 +1,6 @@
 oeps:
     oep-2: true
-    oep-7: false
+    oep-7: true
     oep-18: true
 
 tags:

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def is_requirement(line):
 
 setup(
     name='staff_graded-xblock',
-    version='1.5',
+    version='1.5.1',
     description='Staff Graded XBlock',   # TODO: write a better description.
     license='AGPL v3',          # TODO: choose a license: 'AGPL v3' and 'Apache 2.0' are popular.
     classifiers=[
@@ -54,7 +54,6 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.8',
         'Framework :: Django',
         'Framework :: Django :: 2.2',


### PR DESCRIPTION
Updating the Python requirements in this repository is currently broken due to testing in Python 3.5.

https://edx.app.opsgenie.com/alert/detail/053f8cdf-296e-47b3-8a76-70d2fcf0d50c-1618918356791/details
https://build.testeng.edx.org/job/staff_graded-xblock-upgrade-python-requirements/21/

Also, bump the patch version to 1, yielding version 1.5.1.